### PR TITLE
Artifactory plugin rework pass 1

### DIFF
--- a/forge-parent-ee/pom.xml
+++ b/forge-parent-ee/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.terracotta.forge</groupId>
     <artifactId>forge-parent</artifactId>
-    <version>8.2-SNAPSHOT</version>
+    <version>9.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>forge-parent-ee</artifactId>
@@ -18,19 +18,10 @@
   <name>forge-parent-ee</name>
   <description>Parent POM for Terracotta Enterprise projects</description>
 
-  <distributionManagement>
-    <repository>
-      <id>terracotta-ee-releases</id>
-      <name>Terracotta EE Releases Repository</name>
-      <url>${terracotta-ee-releases-url}</url>
-    </repository>
-    <snapshotRepository>
-      <id>terracotta-ee-snapshots</id>
-       <uniqueVersion>false</uniqueVersion>
-       <name>Terracotta EE Snapshots Repository</name>
-       <url>${terracotta-ee-snapshots-url}</url>
-    </snapshotRepository>
-  </distributionManagement>
+  <properties>
+    <artifactory-repokey-releases>hyc-webmriab-team-tc01-ee-releases-maven-local</artifactory-repokey-releases>
+    <artifactory-repokey-snapshots>hyc-webmriab-team-tc01-ee-snapshots-maven-local</artifactory-repokey-snapshots>
+  </properties>
 
   <profiles>
   </profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,12 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
-<!--
+  <!--
   CHANGELOG (significant changes)
+  9.0: 
+    Move to Artifactory
   8.1:
     Move to Java 17
     skipCheckStyle => true
@@ -69,7 +74,7 @@
 
   <groupId>org.terracotta.forge</groupId>
   <artifactId>forge-parent</artifactId>
-  <version>8.2-SNAPSHOT</version>
+  <version>9.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>forge-parent</name>
@@ -109,36 +114,12 @@
     <checkstyle-config-file>terracotta-checkstyle/checkstyle.xml</checkstyle-config-file>
     <checkstyle-header-file>terracotta-checkstyle/header.txt</checkstyle-header-file>
 
-    <!-- eg: http://my.nexus.domain -->
-    <nexusUrl>UNSET</nexusUrl>
-    
-    <terracotta-os-snapshots-url>${nexusUrl}/content/repositories/terracotta-os-snapshots</terracotta-os-snapshots-url>
-    <terracotta-snapshots-url>${nexusUrl}/content/repositories/terracotta-snapshots</terracotta-snapshots-url>
-    <terracotta-ee-snapshots-url>${nexusUrl}/content/repositories/terracotta-ee-snapshots</terracotta-ee-snapshots-url>
-    <terracotta-staging-url>${nexusUrl}/content/repositories/terracotta-staging</terracotta-staging-url>
-    <terracotta-os-releases-url>${nexusUrl}/content/repositories/terracotta-os-releases</terracotta-os-releases-url>
-    <terracotta-releases-url>${nexusUrl}/content/repositories/terracotta-releases</terracotta-releases-url>
-    <terracotta-ee-releases-url>${nexusUrl}/content/repositories/terracotta-ee-releases</terracotta-ee-releases-url>
-    <terracotta-patches-url>${nexusUrl}/content/repositories/terracotta-patches</terracotta-patches-url>
-    <terracotta-nexus-staging-url>${nexusUrl}/service/local/staging/deploy/maven2</terracotta-nexus-staging-url>
-    <stagingProfile.openSource>6b2d2a23c465b</stagingProfile.openSource>
-    <stagingProfile.public>6b2f08b6e4907</stagingProfile.public>
-    <stagingProfile.private>6b2fc8d5c18d5</stagingProfile.private>
-  </properties>
+    <artifactory-context-url>https://na.artifactory.swg-devops.com/artifactory</artifactory-context-url>
+    <artifactory-repokey-releases>hyc-webmriab-team-tc01-os-releases-maven-local</artifactory-repokey-releases>
+    <artifactory-repokey-snapshots>hyc-webmriab-team-tc01-os-snapshots-maven-local</artifactory-repokey-snapshots>
+    <artifactory-build-name-prefix>hyc-webmriab-team-tc01/terracotta-v4</artifactory-build-name-prefix>
 
-  <distributionManagement>
-    <repository>
-      <id>terracotta-os-releases</id>
-      <name>Terracotta OS Releases Repository</name>
-      <url>${terracotta-os-releases-url}</url>
-    </repository>
-    <snapshotRepository>
-      <id>terracotta-os-snapshots</id>
-      <uniqueVersion>false</uniqueVersion>
-      <name>Terracotta OS Snapshots Repository</name>
-      <url>${terracotta-os-snapshots-url}</url>
-    </snapshotRepository>
-  </distributionManagement>
+  </properties>
 
   <profiles>
     <profile>
@@ -149,6 +130,154 @@
           <name>Terracotta Patches Repository</name>
           <url>${terracotta-patches-url}</url>
         </repository>
+      </distributionManagement>
+    </profile>
+
+    <profile>
+      <!-- 
+        In this (default) mode, 
+        mvn deploy uses artifactory plugin to create build-info.
+        This requires setting artifactory-build-name in child pom.
+        and Environment variables for credentials at deploy time
+        To disable, pass -Ddirect-deploy
+      -->
+      <id>artifactory</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+        <property>
+          <name>!direct-deploy</name>
+        </property>
+      </activation>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.jfrog.buildinfo</groupId>
+              <artifactId>artifactory-maven-plugin</artifactId>
+              <version>3.6.1</version>
+              <executions>
+                <execution>
+                  <id>build-info</id>
+                  <goals>
+                    <goal>publish</goal>
+                  </goals>
+                  <configuration>
+                    <artifactory>
+                      <includeEnvVars>true</includeEnvVars>
+                      <envVarsExcludePatterns>
+                        *password*,*secret*,*key*,*token*,*passphrase*</envVarsExcludePatterns>
+                      <envVarsIncludePatterns>*os*</envVarsIncludePatterns>
+                      <timeoutSec>60</timeoutSec>
+                    </artifactory>
+                    <buildInfo>
+                      <!-- 
+                      <agentName>..</agentName>
+								      <agentVersion>..</agentVersion> 
+                      -->
+                      <buildName>${artifactory-build-name-prefix}/${artifactory-build-name}</buildName>
+                      <buildNumber>${buildnumber}</buildNumber>
+                      <buildUrl>{{BUILD_URL}}</buildUrl>
+                      <!-- If you'd like to associate the published build-info with a
+								JFrog Project, add the project key here -->
+                      <project>{{ARTIFACTORY_PROJECT}}</project>
+
+                      <!-- 
+                      <buildNumbersNotToDelete></buildNumbersNotToDelete>
+                      <buildRetentionMaxDays></buildRetentionMaxDays>
+                      <buildRetentionCount></buildRetentionCount>
+                       -->
+                      <!-- may need "deleteBuildArtifacts" also, but not in docs -->
+                      <!-- 
+								      <principal>..</principal> 
+                      -->
+                    </buildInfo>
+                    <deployProperties>
+                      <maven>awesome</maven>
+                    </deployProperties>
+                    <publisher>
+                      <contextUrl>${artifactory-context-url}</contextUrl>
+                      <username>{{ARTIFACTORY_DEPLOY_USERNAME}}</username>
+                      <password>{{ARTIFACTORY_DEPLOY_PASSWORD}}</password>
+                      <excludePatterns>${artifactory-deploy-exclude-patterns}</excludePatterns>
+								      <includePatterns>${artifactory-deploy-include-patterns}</includePatterns> 
+                      <repoKey>${artifactory-repokey-releases}</repoKey>
+                      <snapshotRepoKey>${artifactory-repokey-snapshots}</snapshotRepoKey>
+
+                      <publishArtifacts>true</publishArtifacts>
+                      <publishBuildInfo>true</publishBuildInfo>
+
+                      <filterExcludedArtifactsFromBuild>${artifactory-deploy-filter-excluded}</filterExcludedArtifactsFromBuild> 
+                      <!-- If true build information published to Artifactory will include
+								implicit project as well as build-time dependencies -->
+                      <recordAllDependencies>true</recordAllDependencies>
+                      <!-- Minimum file size in KB for which the plugin performs checksum
+								deploy optimization. Default: 10. Set to 0 to disable uploading
+								files with checksum that already exists in Artifactory. -->
+                      <minChecksumDeploySizeKb>10</minChecksumDeploySizeKb>
+                    </publisher>
+                  </configuration>
+                </execution>
+              </executions>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+        <plugins>
+          <plugin>
+            <groupId>org.jfrog.buildinfo</groupId>
+            <artifactId>artifactory-maven-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
+      <!-- 
+      mvn deploy directly uploads without artifactory plugin.
+      To enable: -Ddirect-deploy
+      Unlike nexus-staging plugins, artifactory plugin is not compatible
+      with deploy plugin, so they have to be kept in separate profiles.
+      Using this mode will require configuring "server" elements in 
+      settings.xml with credentials 
+      for every named repo in distributionManagement
+      -->
+      <id>deploy-direct</id>
+      <activation>
+        <property>
+          <name>direct-deploy</name>
+        </property>
+      </activation>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-deploy-plugin</artifactId>
+              <version>3.0.0</version>
+              <configuration>
+                <skip>${skipDeploy}</skip>
+              </configuration>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-deploy-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </build>
+      <distributionManagement>
+        <repository>
+          <id>${artifactory-repokey-releases}</id>
+          <name>Terracotta OS Releases Repository</name>
+          <url>${artifactory-context-url}/${artifactory-repokey-releases}</url>
+        </repository>
+        <snapshotRepository>
+          <id>${artifactory-repokey-snapshots</id>
+          <uniqueVersion>false</uniqueVersion>
+          <name>Terracotta OS Snapshots Repository</name>
+          <url>${artifactory-context-url}/${artifactory-repokey-snapshots}</url>
+        </snapshotRepository>
       </distributionManagement>
     </profile>
   </profiles>
@@ -218,14 +347,6 @@
               </goals>
             </execution>
           </executions>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-deploy-plugin</artifactId>
-          <version>3.0.0</version>
-          <configuration>
-            <skip>${skipDeploy}</skip>
-          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -306,7 +427,8 @@
             </execution>
           </executions>
         </plugin>
-        <!-- NOTE: no default executions defined for surefire/failsafe since we use maven-forge-plugin -->
+        <!-- NOTE: no default executions defined for surefire/failsafe since we use
+        maven-forge-plugin -->
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
@@ -333,19 +455,6 @@
           <configuration>
             <skipITs>${skipTests}</skipITs>
             <reuseForks>false</reuseForks>
-          </configuration>
-        </plugin>
-        <plugin>
-          <groupId>org.sonatype.plugins</groupId>
-          <artifactId>nexus-staging-maven-plugin</artifactId>
-          <version>1.6.13</version>
-          <extensions>true</extensions>
-          <configuration>
-            <!-- The Base URL of Nexus instance where we want to stage -->
-            <nexusUrl>${nexusUrl}</nexusUrl>
-            <!-- The server "id" element from settings to use authentication from -->
-            <serverId>terracotta-nexus-staging</serverId>
-            <skipNexusStagingDeployMojo>${skipDeploy}</skipNexusStagingDeployMojo>
           </configuration>
         </plugin>
         <plugin>
@@ -389,7 +498,8 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
       </plugin>
-      <!-- Ensure that we are compiling with the correct JDK even if we are running on a later version -->
+      <!-- Ensure that we are compiling with the correct JDK even if we are running on a later
+      version -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-toolchains-plugin</artifactId>
@@ -427,7 +537,7 @@
             </configuration>
           </execution>
         </executions>
-      </plugin>      
+      </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>findbugs-maven-plugin</artifactId>
@@ -440,10 +550,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-      </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>


### PR DESCRIPTION
Two deploy modes going forward:

1. Artifactory (like staging) mode that writes build-info, which is metadata associating all deployed artifacts into one thing:
`BUILD_URL=bla ARTIFACTORY_DEPLOY_USERNAME=bla ARTIFACTORY_DEPLOY_PASSWORD=bla mvn deploy -Dbuildnumber=1.2.3`

(don't ask me why this plugin requires explicit config for creds instead of using settings.xml)
I've settled on:
* overriding default plugin behavior with child pom properties
* passing CI specific info like above via environment vars.

2. Non-artifactory (direct maven deploy, each artifact for itself, requires `<server>` auth config in settings.xml):

`mvn deploy -Ddirect-deploy`