### PR TITLE
Optional toolchain vendor specification

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,6 +5,8 @@
 
   <!--
   CHANGELOG (significant changes)
+  9.1:
+    No default vendor requirement
   9.0: 
     Move to Artifactory
   8.1:
@@ -89,9 +91,14 @@
       -Darguments=-Djava.build.version=1.9 -->
     <java.build.version>17</java.build.version>
     <!-- The vendor value to look for in toolchains.xml -->
-    <java.build.vendor>zulu</java.build.vendor>
+    <!-- if this property is empty, does not restrict to a vendor -->
+    <!-- this property must be set on command line, not in a child pom -->
+    <java.build.vendor></java.build.vendor>
     <maven-forge-plugin.version>2.0.7</maven-forge-plugin.version>
     <java.test.version>${java.build.version}</java.test.version>
+    <!-- The vendor value to look for in toolchains.xml -->
+    <!-- if this property is empty, does not restrict to a vendor -->
+    <!-- this property must be set on command line, not in a child pom -->
     <java.test.vendor>${java.build.vendor}</java.test.vendor>
     <maven-javadoc-plugin.version>3.11.2</maven-javadoc-plugin.version>
     <surefire-plugin.version>3.5.2</surefire-plugin.version>
@@ -199,14 +206,14 @@
                       <username>{{ARTIFACTORY_DEPLOY_USERNAME}}</username>
                       <password>{{ARTIFACTORY_DEPLOY_PASSWORD}}</password>
                       <excludePatterns>${artifactory-deploy-exclude-patterns}</excludePatterns>
-								      <includePatterns>${artifactory-deploy-include-patterns}</includePatterns> 
+                      <includePatterns>${artifactory-deploy-include-patterns}</includePatterns>
                       <repoKey>${artifactory-repokey-releases}</repoKey>
                       <snapshotRepoKey>${artifactory-repokey-snapshots}</snapshotRepoKey>
 
                       <publishArtifacts>true</publishArtifacts>
                       <publishBuildInfo>true</publishBuildInfo>
 
-                      <filterExcludedArtifactsFromBuild>${artifactory-deploy-filter-excluded}</filterExcludedArtifactsFromBuild> 
+                      <filterExcludedArtifactsFromBuild>${artifactory-deploy-filter-excluded}</filterExcludedArtifactsFromBuild>
                       <!-- If true build information published to Artifactory will include
 								implicit project as well as build-time dependencies -->
                       <recordAllDependencies>true</recordAllDependencies>
@@ -230,6 +237,76 @@
       </build>
     </profile>
 
+    <profile>
+      <id>toolchain-build-vendor</id>
+      <activation>
+        <property>
+          <name>java.build.vendor</name>
+        </property>
+      </activation>
+
+      <build>
+        <pluginManagement>
+          <plugins>
+            <!-- Ensure that we are compiling with the correct JDK even if we are running on a later
+      version -->
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-toolchains-plugin</artifactId>
+              <executions>
+                <execution>
+                  <goals>
+                    <goal>toolchain</goal>
+                  </goals>
+                </execution>
+              </executions>
+              <!-- 
+                If java.build.vendor is set, this profile will 
+                redefine toolchain selector to include vendor 
+              -->              
+              <configuration>
+                <toolchains>
+                  <jdk>
+                    <version>1.${java.build.version}</version>
+                    <vendor>${java.build.vendor}</vendor>
+                  </jdk>
+                </toolchains>
+              </configuration>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
+    </profile>
+
+    <profile>
+      <id>toolchain-test-vendor</id>
+      <activation>
+        <property>
+          <name>java.test.vendor</name>
+        </property>
+      </activation>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.terracotta</groupId>
+              <artifactId>maven-forge-plugin</artifactId>
+              <version>${maven-forge-plugin.version}</version>
+              <!-- 
+                If java.test.vendor is set, this profile will 
+                redefine toolchain selector to include vendor 
+              -->
+              <configuration>
+                <jdk>
+                  <version>1.${java.test.version}</version>
+                  <vendor>${java.test.vendor}</vendor>
+                </jdk>
+              </configuration>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
+    </profile>
     <profile>
       <!-- 
       mvn deploy directly uploads without artifactory plugin.
@@ -514,7 +591,6 @@
           <toolchains>
             <jdk>
               <version>1.${java.build.version}</version>
-              <vendor>${java.build.vendor}</vendor>
             </jdk>
           </toolchains>
         </configuration>


### PR DESCRIPTION
Remove zulu requirement since we are moving away from it.   
Allow old behavior when properties are set on command line.